### PR TITLE
Fix pass status check in exam report

### DIFF
--- a/organisations_app/models.py
+++ b/organisations_app/models.py
@@ -387,9 +387,8 @@ class CandidateExam(models.Model):
         report['total_answered'] = len(report['questions_answered'])
         report['total_unanswered'] = len(report['questions_unanswered'])
 
-        if self.score is not None and self.examination.total_marks > 0:
-            score_percentage = (self.score / self.examination.total_marks) * 100
-            report['passed'] = score_percentage >= self.examination.passing_marks
+        if self.score is not None:
+            report['passed'] = self.score >= self.examination.passing_marks
 
         # Get overall exam statistics
         all_candidate_exams = CandidateExam.objects.filter(examination=self.examination)


### PR DESCRIPTION
## Summary
- fix pass condition in candidate exam analysis

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683f3d20ca7c83339886562ed726da1e